### PR TITLE
Support Multiple Trigger Chars

### DIFF
--- a/MIT-LICENSE.txt
+++ b/MIT-LICENSE.txt
@@ -1,0 +1,20 @@
+Copyright (c) 2011 Podio, http://podio.com/
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/jquery.mentionsInput.js
+++ b/jquery.mentionsInput.js
@@ -369,14 +369,9 @@
   $.fn.mentionsInput = function (method, settings) {
 
     if (typeof method === 'object' || !method) {
-      settings = method;
+      settings = $.extend(true, {}, defaultSettings, method);
     }
 
-    if (!settings) {
-      settings = {};
-    }
-
-    settings = _.defaults(settings, defaultSettings);
     var outerArguments = arguments;
 
     return this.each(function () {

--- a/jquery.mentionsInput.js
+++ b/jquery.mentionsInput.js
@@ -18,6 +18,7 @@
     minChars      : 2,
     showAvatars   : true,
     elastic       : true,
+	display		  : 'name',
     classes       : {
       autoCompleteItemActive : "active"
     },
@@ -301,7 +302,7 @@
       _.each(results, function (item) {
         var elmListItem = $(settings.templates.autocompleteListItem({
           'id'      : utils.htmlEncode(item.id),
-          'display' : utils.htmlEncode(item.name),
+          'display' : utils.htmlEncode(item[settings.display]),
           'type'    : utils.htmlEncode(item.type),
           'content' : utils.highlightTerm(utils.htmlEncode((item.name)), query)
         }));

--- a/jquery.mentionsInput.js
+++ b/jquery.mentionsInput.js
@@ -139,7 +139,7 @@
 
     function addMention(value, id, type) {
       var currentMessage = getInputBoxValue();
-      var currentTriggerChar = $(this).data('triggerChar');
+      var currentTriggerChar = elmInputBox.data('triggerChar');
 
       // Using a regex to figure out positions
       var regex = new RegExp("\\" + currentTriggerChar + currentDataQuery, "gi");
@@ -327,7 +327,7 @@
       if (query && query.length && query.length >= settings.minChars) {
         settings.onDataRequest.call(this, 'search', query, function (responseData) {
           populateDropdown(query, responseData);
-          $(this).data('triggerChar', triggerChar);
+          elmInputBox.data('triggerChar', triggerChar);
         }, triggerChar);
       }
     }


### PR DESCRIPTION
triggerChar can now be set as just a char, or an array of chars. The trigger char is passed as the last parameter to the onDataRequest callback.
All type and templates now include the type and trigger char.
this commit fixes #5
