### PR TITLE
Support to others displays names on textarea

### DIFF
--- a/jquery.mentionsInput.js
+++ b/jquery.mentionsInput.js
@@ -82,6 +82,7 @@
       elmInputBox.attr('data-mentions-input', 'true');
       elmInputBox.bind('keydown', onInputBoxKeyDown);
       elmInputBox.bind('keypress', onInputBoxKeyPress);
+	  elmInputBox.bind('blur', onInputBoxBlur);
       elmInputBox.bind('input', onInputBoxInput);
       elmInputBox.bind('click', onInputBoxClick);
 
@@ -188,6 +189,10 @@
 
     function onInputBoxClick(e) {
       resetBuffer();
+    }
+
+	function onInputBoxBlur(e) {
+      hideAutoComplete();
     }
 
     function onInputBoxInput(e) {


### PR DESCRIPTION
In some cases, the information that can be sent in the form is different from the name attribute of the object.
