### PR TITLE
Use a deep copy for settings instead of _.defaults

### DIFF
--- a/jquery.mentionsInput.js
+++ b/jquery.mentionsInput.js
@@ -358,14 +358,9 @@
   $.fn.mentionsInput = function (method, settings) {
 
     if (typeof method === 'object' || !method) {
-      settings = method;
+      settings = $.extend(true, {}, defaultSettings, method);
     }
 
-    if (!settings) {
-      settings = {};
-    }
-
-    settings = _.defaults(settings, defaultSettings);
     var outerArguments = arguments;
 
     return this.each(function () {


### PR DESCRIPTION
 If you pass in a custom `templates` object in your `settings` then the default templates are missing. This is because `_.defaults` does not do a deep copy.

In the following commit I use `$.extend` instead of `_.defaults`.

Thanks!
