### PR TITLE
Allow full names to trigger search

### DIFF
--- a/jquery.mentionsInput.js
+++ b/jquery.mentionsInput.js
@@ -287,6 +287,13 @@
       if (e.keyCode == KEY.LEFT || e.keyCode == KEY.RIGHT || e.keyCode == KEY.HOME || e.keyCode == KEY.END) {
         // Defer execution to ensure carat pos has changed after HOME/END keys
         _.defer(resetBuffer);
+
+        // IE9 doesn't fire the oninput event when backspace or delete is pressed. This causes the highlighting
+        // to stay on the screen whenever backspace is pressed after a highlighed word. This is simply a hack
+        // to force updateValues() to fire when backspace/delete is pressed in IE9.
+        if (navigator.userAgent.indexOf("MSIE 9") > -1) {
+          _.defer(updateValues);
+        }
         return;
       }
 

--- a/jquery.mentionsInput.js
+++ b/jquery.mentionsInput.js
@@ -293,11 +293,12 @@
           'id'      : utils.htmlEncode(item.id),
           'display' : utils.htmlEncode(item.name),
           'type'    : utils.htmlEncode(item.type),
-          'content' : utils.highlightTerm(utils.htmlEncode((item.name)), query)
+          'content' : utils.highlightTerm(utils.htmlEncode((item.name)), query),
+          'item'    : item
         }));
 
-        if (index === 0) { 
-          selectAutoCompleteItem(elmListItem); 
+        if (index === 0) {
+          selectAutoCompleteItem(elmListItem);
         }
 
         if (settings.showAvatars) {

--- a/jquery.mentionsInput.js
+++ b/jquery.mentionsInput.js
@@ -110,6 +110,7 @@
     var mentionsCollection = [];
     var inputBuffer = [];
     var currentDataQuery;
+    var cursorEndPosition;
 
     function initTextarea() {
       elmInputBox = $(input);
@@ -129,6 +130,10 @@
       elmInputBox.bind('input', onInputBoxInput);
       elmInputBox.bind('click', onInputBoxClick);
 
+      if (settings.fullNameTrigger) {
+        elmInputBox.bind('keyup mousedown mouseup focus', saveCursorPosition);
+      }
+
       elmInputBox.elastic();
     }
 
@@ -141,6 +146,10 @@
     function initMentionsOverlay() {
       elmMentionsOverlay = $(settings.templates.mentionsOverlay());
       elmMentionsOverlay.prependTo(elmWrapperBox);
+    }
+
+    function saveCursorPosition(e) {
+      cursorEndPosition = utils.getCaratPosition(e.target);
     }
 
     function updateValues() {
@@ -185,7 +194,7 @@
 
       if (settings.fullNameTrigger) {
         // Get the actual carat position using some black magic
-        var currentCaretPosition = utils.getCaratPosition(elmInputBox[0]);
+        var currentCaretPosition = cursorEndPosition;
         var startCaretPosition = currentCaretPosition - currentDataQuery.length;
 
         // Find where to start inserting mention
@@ -251,7 +260,6 @@
       updateMentionsCollection();
       hideAutoComplete();
 
-      // spacebreak
       var space_index = _.lastIndexOf(inputBuffer, " ");
       if (space_index > -1) {
         inputBuffer = inputBuffer.slice(space_index + 1);


### PR DESCRIPTION
When the new 'fullNameTrigger' option is enabled, matching starts when the user enters at least 'minChars' characters starting with a capital letter.

For example, typing "Jo" would show "John Smith" in the drop down if 'minChars' is set to 2. When fullNameTrigger is enabled, 'triggerChar' has no effect.

This is more natural to users since they don't have to type a trigger character to mention somebody else's name.