### PR TITLE
call reset on initialization

### DIFF
--- a/jquery.mentionsInput.js
+++ b/jquery.mentionsInput.js
@@ -327,6 +327,12 @@
       }
     }
 
+    function reset() {
+      elmInputBox.val('');
+      mentionsCollection = [];
+      updateValues();
+    }
+
     // Public methods
     return {
       init : function (options) {
@@ -335,6 +341,7 @@
         initTextarea();
         initAutocomplete();
         initMentionsOverlay();
+        reset();
       },
 
       val : function (callback) {
@@ -347,9 +354,7 @@
       },
 
       reset : function () {
-        elmInputBox.val('');
-        mentionsCollection = [];
-        updateValues();
+        reset();
       },
 
       getMentions : function (callback) {


### PR DESCRIPTION
I noticed that when there is text in the input that contains mentions, and then the user reloads the page, at least Firefox is smart enough to re-fill the previous content into the input field. But since that doesn't trigger the mentionsInput plugin, only the text is shown without any mention highlighting or associated data.

I assume it would be better to just clear everything on initialization instead of leaving "broken" content behind.
Please tell me, if you think otherwise.
