### PR TITLE
changes from Diaspora we'd like to see upstream :-)

### DIFF
--- a/jquery.mentionsInput.js
+++ b/jquery.mentionsInput.js
@@ -176,11 +176,7 @@
 
     function onAutoCompleteItemClick(e) {
       var elmTarget = $(this);
-      var mention = {
-        'value': elmTarget.attr('data-display'),
-        'id':    elmTarget.attr('data-ref-id'),
-        'type':  elmTarget.attr('data-ref-type')
-      };
+      var mention = document[elmTarget.attr('data-uid')];
 
       addMention(mention);
 
@@ -293,15 +289,18 @@
       var elmDropDownList = $("<ul>").appendTo(elmAutocompleteList).hide();
 
       _.each(results, function (item, index) {
+        var itemUid = _.uniqueId('mention_');
+        document[itemUid] = _.extend({}, item, {value: item.name});
+
         var elmListItem = $(settings.templates.autocompleteListItem({
           'id'      : utils.htmlEncode(item.id),
           'display' : utils.htmlEncode(item.name),
           'type'    : utils.htmlEncode(item.type),
           'content' : utils.highlightTerm(utils.htmlEncode((item.name)), query)
-        }));
+        })).attr('data-uid', itemUid);
 
-        if (index === 0) { 
-          selectAutoCompleteItem(elmListItem); 
+        if (index === 0) {
+          selectAutoCompleteItem(elmListItem);
         }
 
         if (settings.showAvatars) {


### PR DESCRIPTION
This is a reimplementation of the changes that were proposed in #21 by @OhaiBBQ and additionally contains something we have at Diaspora, that allows you to specify a mention, the input field should be populated with, initially.
The changes are mainly to allow for custom fields in the mention objects and therefore custom placeholders in the templates, which is needed for Diaspora, because of our user IDs. It also opens up a wide range of different uses, where more or different fields than an ID, name and avatar are needed :)

Please let me know, if this is ok, or if you want anything changed so that we can get this merged and Diaspora can get back to using this plugin in an unmodified version asap.
Thank you!

We're tracking this at diaspora/diaspora#3161
