### PR TITLE
initilaize currentDataQuery to '', in case prefillMention is used

### DIFF
--- a/jquery.mentionsInput.js
+++ b/jquery.mentionsInput.js
@@ -68,7 +68,7 @@
     var mentionsCollection = [];
     var autocompleteItemCollection = {};
     var inputBuffer = [];
-    var currentDataQuery;
+    var currentDataQuery = '';
 
     settings = $.extend(true, {}, defaultSettings, settings );
 


### PR DESCRIPTION
currentDataQuery can't be `undefined` in case the `options.prefillMention` is used, otherwise it will throw an error.
