### PR TITLE
Fix for flickering autocomplete menu

### DIFF
--- a/jquery.mentionsInput.js
+++ b/jquery.mentionsInput.js
@@ -25,7 +25,7 @@
       wrapper                    : _.template('<div class="mentions-input-box"></div>'),
       autocompleteList           : _.template('<div class="mentions-autocomplete-list"></div>'),
       autocompleteListItem       : _.template('<li data-ref-id="<%= id %>" data-ref-type="<%= type %>" data-display="<%= display %>"><%= content %></li>'),
-      autocompleteListItemAvatar : _.template('<img  src="<%= avatar %>" />'),
+      autocompleteListItemAvatar : _.template('<img src="<%= avatar %>" />'),
       autocompleteListItemIcon   : _.template('<div class="icon <%= icon %>"></div>'),
       mentionsOverlay            : _.template('<div class="mentions"><div></div></div>'),
       mentionItemSyntax          : _.template('@[<%= value %>](<%= type %>:<%= id %>)'),
@@ -203,7 +203,6 @@
     function onInputBoxInput(e) {
       updateValues();
       updateMentionsCollection();
-      hideAutoComplete();
 
       var triggerCharIndex = _.lastIndexOf(inputBuffer, settings.triggerChar);
       if (triggerCharIndex > -1) {
@@ -347,6 +346,8 @@
         settings.onDataRequest.call(this, 'search', query, function (responseData) {
           populateDropdown(query, responseData);
         });
+      } else {
+        hideAutoComplete();
       }
     }
 


### PR DESCRIPTION
The dropdown menu flickers as the user types because it's being hidden then re-shown, but not on the same tick (due to the `_.defer`). By pushing `hideAutoComplete()` to within the deferred call, it won't flicker. It's a bit easier on the eyes.
