### PR TITLE
fix bug: if parent element have child div

### DIFF
--- a/jquery.mentionsInput.js
+++ b/jquery.mentionsInput.js
@@ -82,7 +82,7 @@
       elmInputWrapper = elmInputBox.parent();
       elmWrapperBox = $(settings.templates.wrapper());
       elmInputBox.wrapAll(elmWrapperBox);
-      elmWrapperBox = elmInputWrapper.find('> div');
+      elmWrapperBox = elmInputWrapper.find('> div.mentions-input-box');
 
       elmInputBox.attr('data-mentions-input', 'true');
       elmInputBox.bind('keydown', onInputBoxKeyDown);


### PR DESCRIPTION
All children divs were wrapped by elmInputWrapper.find('> div');

This commit fixing this issue.
