### PR TITLE
Specify elmWrapperBox directly with DOM operation

### DIFF
--- a/jquery.mentionsInput.js
+++ b/jquery.mentionsInput.js
@@ -81,8 +81,7 @@
 
       elmInputWrapper = elmInputBox.parent();
       elmWrapperBox = $(settings.templates.wrapper());
-      elmInputBox.wrapAll(elmWrapperBox);
-      elmWrapperBox = elmInputWrapper.find('> div');
+      elmWrapperBox.insertBefore(elmInputBox).append(elmInputBox);
 
       elmInputBox.attr('data-mentions-input', 'true');
       elmInputBox.bind('keydown', onInputBoxKeyDown);


### PR DESCRIPTION
rather than finding with `elmInputWrapper.find('> div')`, which can find unwanted elements in the returned jQuery object, making wrong insertion of other plugin elements.