### PR TITLE
Fixes bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Kenneth Auchenberg  <kenneth@auchenberg.dk>",
     "djhvscf <djhv92@hotmail.com>"
   ],
-  "description": "jquery.mentionsInput is a small, but awesome UI component that allows you to "@mention" someone in a text message, just like you are used to on Facebook or Twitter.",
+  "description": "jquery.mentionsInput is a small, but awesome UI component that allows you to '@mention' someone in a text message, just like you are used to on Facebook or Twitter.",
   "main": [
       "jquery.mentionsInput.js"
   ],


### PR DESCRIPTION
Double quotes around mention breaks the string and causes install errors.
