### PR TITLE
(fixes #104) Repeat mentions with allowRepeat option

### DIFF
--- a/jquery.mentionsInput.js
+++ b/jquery.mentionsInput.js
@@ -42,6 +42,10 @@
     htmlEncode       : function (str) {
       return _.escape(str);
     },
+    //Encodes the character to be used with RegExp
+    regexpEncode     : function (str) {
+      return str.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+    },
 	//
     highlightTerm    : function (value, term) {
       if (!term && !term.length) {
@@ -128,7 +132,7 @@
 
       _.each(mentionsCollection, function (mention) {
         var textSyntax = settings.templates.mentionItemSyntax(mention);
-        syntaxMessage = syntaxMessage.replace(mention.value, textSyntax);
+        syntaxMessage = syntaxMessage.replace(new RegExp(utils.regexpEncode(mention.value), 'g'), textSyntax);
       });
 
       var mentionText = utils.htmlEncode(syntaxMessage); //Encode the syntaxMessage
@@ -138,7 +142,7 @@
         var textSyntax = settings.templates.mentionItemSyntax(formattedMention);
         var textHighlight = settings.templates.mentionItemHighlight(formattedMention);
 
-        mentionText = mentionText.replace(textSyntax, textHighlight);
+        mentionText = mentionText.replace(new RegExp(utils.regexpEncode(textSyntax), 'g'), textHighlight);
       });
 
       mentionText = mentionText.replace(/\n/g, '<br />'); //Replace the escape character for <br />
@@ -180,7 +184,10 @@
       var end = currentMessage.substr(currentCaretPosition, currentMessage.length);
       var startEndIndex = (start + mention.value).length + 1;
 
-      mentionsCollection.push(mention);//Add the mention to mentionsColletions
+      // See if there's the same mention in the list
+      if( !_.find(mentionsCollection, function (object) { return object.id == mention.id; }) ) {
+        mentionsCollection.push(mention);//Add the mention to mentionsColletions
+      }
 
       // Cleaning before inserting the value, otherwise auto-complete would be triggered with "old" inputbuffer
       resetBuffer();


### PR DESCRIPTION
A quick fix that enables duplicate mentions.

I added an option called "allowRepeat" which, when it's set to true, allows users to mention the same person multiple times. Without changing the original design, I personally think this is the best solution. It seems inevitable, by design, that there will be certain bugs such as the same person getting highlighted without triggerChar. I highly recommend that we work on a new design that has a legit parser.

If you have any ideas to fix the bugs without having the design changed, let me know. I would like to work on it. Let's discuss it further. Thanks!
