### PR TITLE
reposition auto complete list if its right position is bigger than input...

### DIFF
--- a/jquery.mentionsInput.js
+++ b/jquery.mentionsInput.js
@@ -457,6 +457,14 @@
       elmAutocompleteList.css('width', '15em'); // Sort of a guess
       elmAutocompleteList.css('left', position.left);
       elmAutocompleteList.css('top', lineHeight + position.top);
+      //check if the right position of auto complete is larger than the right position of the input
+      //if yes, reset the lest of auto complete to make it right-align with caret
+      elmInputBoxRight = elmInputBox.offset().left + elmInputBox.width();
+      elmAutocompleteListRight =elmAutocompleteList.offset().left + elmAutocompleteList.width();
+      if (elmInputBoxRight < elmAutocompleteListRight) {
+        elmAutocompleteList.css('left', Math.abs(elmAutocompleteList.position().left - elmAutocompleteList.width()));
+      }
+
     }
 
 	//Resets the text area

--- a/jquery.mentionsInput.js
+++ b/jquery.mentionsInput.js
@@ -457,14 +457,14 @@
       elmAutocompleteList.css('width', '15em'); // Sort of a guess
       elmAutocompleteList.css('left', position.left);
       elmAutocompleteList.css('top', lineHeight + position.top);
-      //check if the right position of auto complete is larger than the right position of the input
-      //if yes, reset the lest of auto complete to make it right-align with caret
-      elmInputBoxRight = elmInputBox.offset().left + elmInputBox.width();
-      elmAutocompleteListRight =elmAutocompleteList.offset().left + elmAutocompleteList.width();
-      if (elmInputBoxRight < elmAutocompleteListRight) {
-        elmAutocompleteList.css('left', Math.abs(elmAutocompleteList.position().left - elmAutocompleteList.width()));
-      }
 
+      //check if the right position of auto complete is larger than the right position of the input
+      //if yes, reset the left of auto complete list to make it fit the input
+      var elmInputBoxRight = elmInputBox.offset().left + elmInputBox.width(),
+          elmAutocompleteListRight = elmAutocompleteList.offset().left + elmAutocompleteList.width();
+      if (elmInputBoxRight <= elmAutocompleteListRight) {
+          elmAutocompleteList.css('left', Math.abs(elmAutocompleteList.position().left - (elmAutocompleteListRight - elmInputBoxRight)));
+      }
     }
 
 	//Resets the text area


### PR DESCRIPTION
check if the right position of auto complete is larger than the right position of the input, if yes, reset the left of auto complete list to make it fit the input
![screen shot 2015-03-26 at 4 30 04 pm](https://cloud.githubusercontent.com/assets/5163135/6844324/4c4b8c8a-d3dd-11e4-95ac-7b5b1aef3016.png)
