### PR TITLE
Prevent [Enter] keypress propagating.

### DIFF
--- a/jquery.mentionsInput.js
+++ b/jquery.mentionsInput.js
@@ -378,6 +378,7 @@
                 case KEY.RETURN: //If the key pressed was RETURN or TAB
                 case KEY.TAB:
                     if (elmActiveAutoCompleteItem && elmActiveAutoCompleteItem.length) { //If the elmActiveAutoCompleteItem exists
+                        e.stopImmediatePropagation();
                         elmActiveAutoCompleteItem.trigger('mousedown'); //Calls the mousedown event
                         return false;
                     }


### PR DESCRIPTION
Allows [Enter] key to be bound for the purposes of submitting.

Resolves #159 
