### PR TITLE
Bug Fixes for Usage with Android Soft Keyboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "harvs1789uk-jquery-mentions",
+  "version": "1.0.0",
+  "description": "A fork of podio/jquery-mentions-input which provides best efforts at supporting Android soft keyboard usage ",
+  "main": "jquery.mentionsInput.js",
+  "directories": {
+    "doc": "docs",
+    "lib": "lib"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/HARVS1789UK/jquery-mentions-input.git"
+  },
+  "keywords": [
+    "jQuery",
+    "Android",
+    "tagging"
+  ],
+  "author": "joe.harvey@nexustech.je",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/HARVS1789UK/jquery-mentions-input/issues"
+  },
+  "homepage": "https://github.com/HARVS1789UK/jquery-mentions-input#readme"
+}


### PR DESCRIPTION
As per [this existing issue](https://github.com/podio/jquery-mentions-input/issues/127) the jquery-mentions-input package does not work when trying to @mention things when using Chrome for Android (and probably any other browser on Android, though I haven't checked).

I have based my bug fix on some of the suggestions in that issue. On top of the existing issue raised regarding the keypress event on Android (which[ is now deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Document/keypress_event)) no firing at all, I I also found that the soft keyboard on Android seems to return `undefined` 0 or 229 (which I think is 'keyboard buffer busy) for both `e.keyCode` and `e.which` meaning that much of the logic to update the inputBuffer and decide whether to undertake `doSearch()` was also failing and it was impossible to identify clicks of the del/backspace key

This fix is still a bit of a hack, which doesn't provide any support for text edits made anywhere but the end of the textarea input (e.g. adding/updating text in the middle of the textarea won't work as expected), but seems to at least provide some support for Android